### PR TITLE
Update: I've officially become kubestronaut

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 ### About AJ
 Multilingual Security Engineer @LY Corp, ~Scratch~ Golfer, ~Golden~ [Kubestronaut](https://www.cncf.io/training/kubestronaut/?_sft_lf-country=kr), Fitness Enthusiast, [Credly Badge](https://www.credly.com/users/mlajkim/badges) Collector.
+
+### AJ Used to be
+[Leetcoder](https://leetcode.com/u/mlajkim/), Avid Pianist

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 ### About AJ
-Multilingual Security Engineer @LY Corp, ~Scratch~ Golfer, ~Golden [Kubestronaut](https://www.cncf.io/training/kubestronaut/?_sft_lf-country=kr)~, Fitness Enthusiast, [Credly Badge](https://www.credly.com/users/mlajkim/badges) Collector.
+Multilingual Security Engineer @LY Corp, ~Scratch~ Golfer, ~Golden~ [Kubestronaut](https://www.cncf.io/training/kubestronaut/?_sft_lf-country=kr), Fitness Enthusiast, [Credly Badge](https://www.credly.com/users/mlajkim/badges) Collector.


### PR DESCRIPTION
# Background
I've just become an official kubestronaut:

<img width="780" height="542" alt="image" src="https://github.com/user-attachments/assets/57b4d53c-b49c-4216-b04d-7b5315c2757c" />

## What's done?
Remove the cross for the `kubestronaut` part 

## What's not done?
I am still not the golden kubestronaut, so the ~golden~ stays the same.